### PR TITLE
Reorder Notice Board card to first position

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -328,6 +328,53 @@ const Index = () => {
                 </h2>
 
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+                  {/* Notice Board */}
+                  <Card>
+                    <CardContent className="p-6">
+                      <div className="flex items-center mb-4">
+                        <Bell className="w-5 h-5 text-orange-600 mr-2" />
+                        <span className="font-medium text-slate-900">
+                          Notice Board
+                        </span>
+                      </div>
+                      <div className="text-sm text-slate-600 mb-4">
+                        You're viewing for: All Branch
+                      </div>
+                      <div className="space-y-3 mb-4">
+                        <div className="border-l-4 border-orange-500 pl-3">
+                          <div className="font-medium text-slate-900 text-sm">
+                            Holiday Notice - Diwali Celebration
+                          </div>
+                          <div className="text-xs text-slate-500 mt-1">
+                            2 hours ago
+                          </div>
+                          <div className="text-xs text-slate-600 mt-1">
+                            Office will remain closed on October 24th for
+                            Diwali...
+                          </div>
+                        </div>
+                        <div className="border-l-4 border-blue-500 pl-3">
+                          <div className="font-medium text-slate-900 text-sm">
+                            New Health Insurance Policy Updates
+                          </div>
+                          <div className="text-xs text-slate-500 mt-1">
+                            1 day ago
+                          </div>
+                          <div className="text-xs text-slate-600 mt-1">
+                            Important updates regarding the company health
+                            insurance polic...
+                          </div>
+                        </div>
+                      </div>
+                      <Button
+                        variant="ghost"
+                        className="w-full text-orange-600 hover:bg-orange-50"
+                      >
+                        View All Notices
+                      </Button>
+                    </CardContent>
+                  </Card>
+
                   {/* Monthly Attendance Summary */}
                   <Card>
                     <CardContent className="p-6">
@@ -399,53 +446,6 @@ const Index = () => {
 
                       <Button variant="outline" className="w-full">
                         View Full Attendance
-                      </Button>
-                    </CardContent>
-                  </Card>
-
-                  {/* Notice Board */}
-                  <Card>
-                    <CardContent className="p-6">
-                      <div className="flex items-center mb-4">
-                        <Bell className="w-5 h-5 text-orange-600 mr-2" />
-                        <span className="font-medium text-slate-900">
-                          Notice Board
-                        </span>
-                      </div>
-                      <div className="text-sm text-slate-600 mb-4">
-                        You're viewing for: All Branch
-                      </div>
-                      <div className="space-y-3 mb-4">
-                        <div className="border-l-4 border-orange-500 pl-3">
-                          <div className="font-medium text-slate-900 text-sm">
-                            Holiday Notice - Diwali Celebration
-                          </div>
-                          <div className="text-xs text-slate-500 mt-1">
-                            2 hours ago
-                          </div>
-                          <div className="text-xs text-slate-600 mt-1">
-                            Office will remain closed on October 24th for
-                            Diwali...
-                          </div>
-                        </div>
-                        <div className="border-l-4 border-blue-500 pl-3">
-                          <div className="font-medium text-slate-900 text-sm">
-                            New Health Insurance Policy Updates
-                          </div>
-                          <div className="text-xs text-slate-500 mt-1">
-                            1 day ago
-                          </div>
-                          <div className="text-xs text-slate-600 mt-1">
-                            Important updates regarding the company health
-                            insurance polic...
-                          </div>
-                        </div>
-                      </div>
-                      <Button
-                        variant="ghost"
-                        className="w-full text-orange-600 hover:bg-orange-50"
-                      >
-                        View All Notices
                       </Button>
                     </CardContent>
                   </Card>


### PR DESCRIPTION
Move the Notice Board card component from the fourth position to the first position in the dashboard grid layout.

The Notice Board card containing holiday notices and health insurance policy updates is now displayed as the first card in the grid instead of appearing after the Monthly Attendance Summary and other cards.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4`

🔗 [Edit in Builder.io](https://builder.io/app/projects/d6a33531b6824848a1706994410f9630/quantum-oasis)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d6a33531b6824848a1706994410f9630</projectId>-->
<!--<branchName>quantum-oasis</branchName>-->