### PR TITLE
Move Office Hours section above progress bar

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -305,18 +305,6 @@ const Index = () => {
                         </div>
                       </div>
 
-                      <div className="bg-blue-50 border border-blue-200 rounded p-3 mb-3">
-                        <div className="flex items-center">
-                          <Clock className="w-4 h-4 text-blue-600 mr-2" />
-                          <span className="text-sm font-medium text-blue-800">
-                            Office Hours
-                          </span>
-                        </div>
-                        <div className="text-sm text-blue-600 mt-1">
-                          09:00 AM To 06:00 PM
-                        </div>
-                      </div>
-
                       <div className="bg-orange-50 border border-orange-200 rounded p-3 mb-4">
                         <div className="flex items-start">
                           <div className="flex-shrink-0 w-5 h-5 bg-orange-500 rounded-full flex items-center justify-center mr-3 mt-0.5">
@@ -333,6 +321,18 @@ const Index = () => {
                               Approval, to yr Reporting Manager...
                             </div>
                           </div>
+                        </div>
+                      </div>
+
+                      <div className="bg-blue-50 border border-blue-200 rounded p-3 mb-3">
+                        <div className="flex items-center">
+                          <Clock className="w-4 h-4 text-blue-600 mr-2" />
+                          <span className="text-sm font-medium text-blue-800">
+                            Office Hours
+                          </span>
+                        </div>
+                        <div className="text-sm text-blue-600 mt-1">
+                          09:00 AM To 06:00 PM
                         </div>
                       </div>
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -286,6 +286,18 @@ const Index = () => {
                         </div>
                       </div>
 
+                      <div className="bg-blue-50 border border-blue-200 rounded p-3 mb-4">
+                        <div className="flex items-center">
+                          <Clock className="w-4 h-4 text-blue-600 mr-2" />
+                          <span className="text-sm font-medium text-blue-800">
+                            Office Hours
+                          </span>
+                        </div>
+                        <div className="text-sm text-blue-600 mt-1">
+                          09:00 AM To 06:00 PM
+                        </div>
+                      </div>
+
                       <div className="mb-4">
                         <div className="flex items-center justify-between mb-2">
                           <span className="text-sm font-medium">
@@ -321,18 +333,6 @@ const Index = () => {
                               Approval, to yr Reporting Manager...
                             </div>
                           </div>
-                        </div>
-                      </div>
-
-                      <div className="bg-blue-50 border border-blue-200 rounded p-3 mb-3">
-                        <div className="flex items-center">
-                          <Clock className="w-4 h-4 text-blue-600 mr-2" />
-                          <span className="text-sm font-medium text-blue-800">
-                            Office Hours
-                          </span>
-                        </div>
-                        <div className="text-sm text-blue-600 mt-1">
-                          09:00 AM To 06:00 PM
                         </div>
                       </div>
 


### PR DESCRIPTION
Repositioned the Office Hours component to appear earlier in the layout.

Changes:
- Moved Office Hours section from below the progress bar to above it
- Updated bottom margin from mb-3 to mb-4 for consistent spacing
- No other modifications to the component content or styling

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 6`

🔗 [Edit in Builder.io](https://builder.io/app/projects/d6a33531b6824848a1706994410f9630/pixel-sanctuary)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d6a33531b6824848a1706994410f9630</projectId>-->
<!--<branchName>pixel-sanctuary</branchName>-->