### PR TITLE
Make AppHeader responsive on mobile devices

### DIFF
--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -5,7 +5,7 @@ import { Bell, Plus, RefreshCw, ChevronDown } from "lucide-react";
 
 export function AppHeader() {
   return (
-    <header className="h-16 border-b border-slate-200 bg-white px-6 flex items-center justify-between fixed top-0 left-64 right-0 z-50">
+    <header className="h-16 border-b border-slate-200 bg-white px-6 flex items-center justify-between fixed top-0 left-0 md:left-64 right-0 z-50">
       <div className="flex items-center space-x-4">
         <SidebarTrigger className="h-8 w-8" />
         <div className="flex items-center space-x-6">


### PR DESCRIPTION
Updates the AppHeader component to be responsive on mobile devices.

Changes:
- Modified the left positioning from `left-64` to `left-0 md:left-64`
- Header now starts at left edge on mobile and maintains 64 units offset on medium screens and larger

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 11`

🔗 [Edit in Builder.io](https://builder.io/app/projects/402e7dd9c21b4d6686b6b3a065c8ef30/flare-haven)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>402e7dd9c21b4d6686b6b3a065c8ef30</projectId>-->
<!--<branchName>flare-haven</branchName>-->