### PR TITLE
Remove mobile dashboard title and add user icon

### DIFF
--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -49,10 +49,8 @@ export function AppHeader() {
             </div>
           </div>
 
-          {/* Mobile center title */}
-          <div className="flex-1 flex justify-center md:hidden">
-            <h1 className="text-lg font-semibold text-foreground">DASHBOARD</h1>
-          </div>
+          {/* Mobile center title - Dashboard text removed as requested */}
+          <div className="flex-1 flex justify-center md:hidden"></div>
 
           {/* Mobile CREATE button */}
           <Button className="bg-blue-600 hover:bg-blue-700 text-white h-8 px-3 text-sm md:hidden">

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -102,8 +102,13 @@ export function AppSidebar() {
               />
             </div>
             <div className="text-center">
-              <div className="flex items-center space-x-1">
+              <div className="flex items-center justify-center space-x-2">
                 <h3 className="font-semibold text-foreground">Bhaskar Ghosh</h3>
+                <img
+                  src="https://cdn.builder.io/api/v1/assets/62c95941e2ef4fb390e9f53735b0fcbd/image-eef20a?format=webp&width=800"
+                  alt="User Icon"
+                  className="w-5 h-5 object-contain"
+                />
                 <div className="w-4 h-4 bg-green-500 rounded-full flex items-center justify-center">
                   <div className="w-2 h-2 bg-white rounded-full"></div>
                 </div>


### PR DESCRIPTION
This pull request makes two changes to the UI components:

**AppHeader.tsx:**
- Removed the "DASHBOARD" text from the mobile center title section
- Kept the container div but made it empty

**AppSidebar.tsx:**
- Added a user icon image next to the "Bhaskar Ghosh" name
- Updated the flex container to use `justify-center` and increased spacing from `space-x-1` to `space-x-2`
- The new icon is 20x20 pixels and uses a webp image from cdn.builder.io

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 15`

🔗 [Edit in Builder.io](https://builder.io/app/projects/c1457ee47d14499a9f30d0826925d4cd/cosmos-zone)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>c1457ee47d14499a9f30d0826925d4cd</projectId>-->
<!--<branchName>cosmos-zone</branchName>-->